### PR TITLE
Adding project to cache the ruby build on the extras builder.

### DIFF
--- a/omnibus-dcm-agent/config/projects/dcm-builder-cache.rb
+++ b/omnibus-dcm-agent/config/projects/dcm-builder-cache.rb
@@ -1,0 +1,27 @@
+#
+# Copyright 2015 YOUR NAME
+#
+# All Rights Reserved.
+#
+
+name "dcm-builder-cache"
+maintainer "DCM"
+homepage "https://enstratius.com"
+
+install_dir "/opt/#{name}"
+
+build_version "0.5.2" # SEARCH_TOKEN do not delete
+#build_version Omnibus::BuildVersion.semver
+build_iteration 1
+
+# Creates required build directories
+dependency "preparation"
+
+dependency "puppet-gem"
+dependency "ec2-ami-tools"
+
+# Version manifest file
+dependency "version-manifest"
+
+exclude "**/.git"
+exclude "**/bundler/git"


### PR DESCRIPTION
We cannot just use the extras package because something about the
ossec build is causing VMs to lock up.
